### PR TITLE
use_binary_buffer

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1426,6 +1426,10 @@ defmodule Calendar.ISO do
     append_zone(buffer, utc_offset, std_offset, zone_abbr, time_zone)
   end
 
+  def offset_to_string(utc, std, zone, format) do
+    append_offset("", utc, std, zone, format)
+  end
+
   defp append_offset(buffer, 0, 0, "Etc/UTC", _format), do: <<buffer::binary, ?Z>>
 
   defp append_offset(buffer, utc, std, _zone, format) do


### PR DESCRIPTION
 ```                                                                                                                                                                            
Name                                            ips        average  deviation         median         99th %
Calendar.ISO.datetime_to_string              3.59 M        0.28 μs  ±5277.00%        0.24 μs        0.37 μs
Calendar.BinaryISO.datetime_to_string        0.98 M        1.02 μs   ±652.26%        0.90 μs        1.63 μs

Comparison: 
Calendar.ISO.datetime_to_string              3.59 M
Calendar.BinaryISO.datetime_to_string        0.98 M - 3.65x slower +0.74 μs

Extended statistics: 

Name                                          minimum        maximum    sample size                     mode
Calendar.ISO.datetime_to_string               0.20 μs    16790.52 μs         4.72 M                  0.24 μs
Calendar.BinaryISO.datetime_to_string         0.77 μs     5112.77 μs         1.68 M                  0.89 μs

Memory usage statistics:

Name                                     Memory usage
Calendar.ISO.datetime_to_string               0.41 KB
Calendar.BinaryISO.datetime_to_string         3.10 KB - 7.49x memory usage +2.69 KB

**All measurements for memory usage were the same**

Profiling Calendar.ISO.datetime_to_string with eprof...

Profile results of #PID<0.904639.0>
#                                           CALLS     % TIME µS/CALL
Total                                          26 100.0   17    0.65
Calendar.ISO.time_to_iodata_guarded/5           1  0.00    0    0.00
Calendar.ISO.time_to_iodata_format/4            1  0.00    0    0.00
Calendar.ISO.time_to_iodata/5                   1  0.00    0    0.00
Calendar.ISO.naive_datetime_to_string/8         1  0.00    0    0.00
Calendar.ISO.naive_datetime_to_string/7         1  0.00    0    0.00
Calendar.ISO.naive_datetime_to_iodata/8         1  0.00    0    0.00
Calendar.ISO.microseconds_to_iodata/2           1  0.00    0    0.00
Calendar.ISO.date_to_iodata_guarded/4           1  0.00    0    0.00
Calendar.ISO.date_to_iodata/4                   1  0.00    0    0.00
anonymous fn/0 in CalendarStringBench.run/0     1  5.88    1    1.00
:erlang.iolist_to_binary/1                      1 17.65    3    3.00
:erlang.integer_to_binary/1                     7 17.65    3    0.43
Calendar.ISO.zero_pad/2                         7 17.65    3    0.43
:erlang.apply/2                                 1 41.18    7    7.00

Profile done over 14 matching functions

Profiling Calendar.BinaryISO.datetime_to_string with eprof...

Profile results of #PID<0.904641.0>
#                                             CALLS     % TIME µS/CALL
Total                                            95 100.0   47    0.49
Calendar.BinaryISO.naive_datetime_to_string/8     1  0.00    0    0.00
Calendar.BinaryISO.naive_datetime_to_string/7     1  0.00    0    0.00
Calendar.BinaryISO.append_time_format/5           1  0.00    0    0.00
Calendar.BinaryISO.append_time/6                  1  0.00    0    0.00
Calendar.BinaryISO.append_microseconds/3          1  0.00    0    0.00
Calendar.BinaryISO.append_date/5                  1  0.00    0    0.00
String.length/1                                   7  2.13    1    0.14
:unicode_util.gc_extend/3                         7  2.13    1    0.14
:unicode_util.gc_1/1                              7  2.13    1    0.14
:unicode_util.cp/1                                7  2.13    1    0.14
anonymous fn/0 in CalendarStringBench.run/0       1  2.13    1    1.00
:erlang.apply/2                                   1  6.38    3    3.00
:erlang.integer_to_binary/1                       7  6.38    3    0.43
Calendar.BinaryISO.append_zero_padded/3           7 14.89    7    1.00
:unicode_util.gc/1                               14 17.02    8    0.57
String.length/2                                  21 21.28   10    0.48
String.skip_length/2                             10 23.40   11    1.10

Profile done over 17 matching functions                                                         
```                                             
```
benchee module:
```
defmodule CalendarStringBench do
  def run do
    datetime = ~U[2024-12-30 12:21:45.000123Z]

    Benchee.run(
      %{
        "Calendar.ISO.datetime_to_string" => fn ->
          Calendar.ISO.naive_datetime_to_string(
            datetime.year,
            datetime.month,
            datetime.day,
            datetime.hour,
            datetime.minute,
            datetime.second,
            datetime.microsecond
          )
        end,
        "Calendar.BinaryISO.datetime_to_string" => fn ->
          Calendar.BinaryISO.naive_datetime_to_string(
            datetime.year,
            datetime.month,
            datetime.day,
            datetime.hour,
            datetime.minute,
            datetime.second,
            datetime.microsecond
          )
        end
      },
      profile_after: true,
      time: 2,
      memory_time: 2,
      formatters: [
        {Benchee.Formatters.HTML, file: "bench/output/calendar_string.html"},
        {Benchee.Formatters.Console, extended_statistics: true}
      ]
    )
  end
end

# Run the benchmark
CalendarStringBench.run()
```